### PR TITLE
fix: resolved issue with hard-coded declutter property

### DIFF
--- a/packages/map-core/MapVectorLayer.vue
+++ b/packages/map-core/MapVectorLayer.vue
@@ -213,7 +213,7 @@ export default {
         extent: this.extent,
         zIndex: this.zIndex,
         style: this.layerStyle || styles.createDefaultStyleFunction(this.labelAttribute, this.labelOnly, false),
-        declutter: true,
+        declutter: this.declutter,
         visible: this.visible
       })
 

--- a/packages/map-core/MapVectorTileLayer.vue
+++ b/packages/map-core/MapVectorTileLayer.vue
@@ -211,7 +211,7 @@ export default {
         extent: this.extent,
         zIndex: this.zIndex,
         style: this.mapboxStyle ? undefined : (this.layerStyle || styles.createDefaultStyleFunction(this.labelAttribute, this.labelOnly, false)),
-        declutter: true,
+        declutter: this.declutter,
         visible: this.visible
       })
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING.md BEFORE CREATING A PR

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use https://www.conventionalcommits.org/en/v1.0.0/ for all commit structures -->

## Description
<!-- Describe your changes in detail -->
<!-- Note any issues/tickets that are resolved by this PR -->
<!-- e.g. resolves MYVIC-75 or fixes MYVIC-75  -->
This change fixes a minor issue where the declutter prop was ignored on the Vector and Vector Tile map layers and a hard-coded value of true was being used.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | storybook | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core
